### PR TITLE
Remove duplicate JwtTokenHelper

### DIFF
--- a/src/main/java/exe_hag_workshop_app/controller/AuthController.java
+++ b/src/main/java/exe_hag_workshop_app/controller/AuthController.java
@@ -30,8 +30,6 @@ import org.springframework.web.bind.annotation.*;
 @CrossOrigin(origins = "*")
 public class AuthController {
 
-    @Autowired
-    JwtTokenHelper jwtTokenHelpers;
 
     @Autowired
     UserRepository userRepository;
@@ -60,7 +58,7 @@ public class AuthController {
         try {
             Users users = userRepository.findByEmail(loginRequest.getEmail());
             if (users != null && passwordEncoder.matches(loginRequest.getPassword(), users.getPassword())) {
-                String jwt = jwtTokenHelpers.generateToken(users);
+                String jwt = jwtTokenHelper.generateToken(users);
                 LoginResponse loginResponse = new LoginResponse();
                 loginResponse.setToken(jwt);
                 return ResponseEntity.ok(loginResponse);


### PR DESCRIPTION
## Summary
- keep just one JwtTokenHelper field in `AuthController`
- update login to use the remaining helper

## Testing
- `./mvnw -q test` *(fails: Maven download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68504819b3a88322929923e46cad91df